### PR TITLE
Port 443 needs to be set after letsencrypt is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ git push dokku master
 
 ### Manually set proxy settings
 ```bash
-dokku proxy:ports-set plausible http:80:8000 https:443:8000
+dokku proxy:ports-set plausible http:80:8000
 ```
 
 ## SSL certificate
 
-Last but not least, we can go an grab the SSL certificate from [Let's
+We can then go an grab the SSL certificate from [Let's
 Encrypt](https://letsencrypt.org/).
 
 ```bash
@@ -181,6 +181,11 @@ dokku config:set --no-restart plausible DOKKU_LETSENCRYPT_EMAIL=you@example.com
 
 # Generate certificate
 dokku letsencrypt plausible
+```
+
+## Proxy https port
+```bash
+dokku proxy:ports-set plausible http:80:8000 https:443:8000
 ```
 
 ## Wrapping up


### PR DESCRIPTION
If you map port 443 before enabling letsencrypt, the nginx.conf file will be modified to map to a non-existing tls file.

This will prevent nginx from properly reloading, and crash all non-default apps.

So it's easier to first map port 80, enable letsencrypt, then map port 443.

(we need to map port 80 first, otherwise we can't serve a .well-known)