### PR TITLE
fix: make update script portable across macOS and Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PLAUSIBLE_VERSION="v3.2.0"
+ARG PLAUSIBLE_VERSION="v3.2.1"
 
 FROM ghcr.io/plausible/community-edition:$PLAUSIBLE_VERSION
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](.github/images/repo_header.png)
 
-[![Plausible](https://img.shields.io/badge/Plausible-3.2.0-blue.svg)](https://github.com/plausible/analytics/releases/tag/v3.2.0)
+[![Plausible](https://img.shields.io/badge/Plausible-3.2.1-blue.svg)](https://github.com/plausible/analytics/releases/tag/v3.2.1)
 [![Dokku](https://img.shields.io/badge/Dokku-Repo-blue.svg)](https://github.com/dokku/dokku)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/d1ceward-on-dokku/plausible_on_dokku/graphs/commit-activity)
 

--- a/update
+++ b/update
@@ -2,6 +2,15 @@
 set -eo pipefail
 trap "exit" INT
 
+# Portable sed -i wrapper (BSD/macOS vs. GNU/Linux)
+sedi() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 # Pull upstream changes
 echo -e "\033[0;32m====>\033[0m Pull origin..."
 git pull
@@ -11,21 +20,23 @@ echo -e "\033[0;32m====>\033[0m Initial check..."
 # Get current release name
 CURRENT_RELEASE=$(git tag --sort=committerdate | tail -1)
 
-# Get lastest release name
-RELEASE=$(curl -s https://api.github.com/repos/plausible/analytics/tags | jq | grep -o '"v[0-9]*\.[0-9]*\.[0-9]*"'| head -1 | sed 's/v//g; s/\"//g')
+# Get latest release name
+RELEASE=$(curl -s https://api.github.com/repos/plausible/analytics/tags \
+  | jq -r '.[0].name' \
+  | sed 's/^v//')
 
 # Exit script if already up to date
-if [ "v${RELEASE}" = $CURRENT_RELEASE ]; then
+if [ "v${RELEASE}" = "$CURRENT_RELEASE" ]; then
   echo -e "\033[0;32m=>\033[0m Already up to date..."
   exit 0
 fi
 
 # Replace "from" line in dockerfile with the new release
-sed -i "s#ARG PLAUSIBLE_VERSION.*#ARG PLAUSIBLE_VERSION=\"v${RELEASE}\"#" Dockerfile
+sedi "s#ARG PLAUSIBLE_VERSION.*#ARG PLAUSIBLE_VERSION=\"v${RELEASE}\"#" Dockerfile
 
 # Replace README link to plausible release
 PLAUSIBLE_BADGE="[![Plausible](https://img.shields.io/badge/Plausible-${RELEASE}-blue.svg)](https://github.com/plausible/analytics/releases/tag/v${RELEASE})"
-sed -i "s#\[\!\[Plausible\].*#${PLAUSIBLE_BADGE}#" README.md
+sedi "s#\[\!\[Plausible\].*#${PLAUSIBLE_BADGE}#" README.md
 
 # Push changes
 git add Dockerfile README.md


### PR DESCRIPTION
## Problem
The `update.sh` script used `sed -i "…"` which is incompatible with
BSD sed on macOS — it requires an explicit backup suffix (`sed -i ''`),
whereas GNU sed on Linux treats the empty string as a script argument.

## Changes
- Add a `sedi()` wrapper that selects the correct `sed -i` syntax based
  on `$OSTYPE`
- Simplify the Plausible release parsing: replace the brittle
  `jq | grep | sed` pipeline with `jq -r '.[0].name'`
- Quote `$CURRENT_RELEASE` to prevent word-splitting issues

## Tested on
- [x] Linux (GNU sed)
- [x] macOS (BSD sed)